### PR TITLE
feat: rework burn transactions

### DIFF
--- a/pallet-tft-bridge/src/lib.rs
+++ b/pallet-tft-bridge/src/lib.rs
@@ -169,7 +169,7 @@ pub mod pallet {
         MintCompleted(MintTransaction<T::AccountId, T::BlockNumber>),
         MintTransactionExpired(Vec<u8>, u64, T::AccountId),
         // Burn events
-        BurnTransactionCreated(T::AccountId, u64, Vec<u8>, u64),
+        BurnTransactionCreated(u64, T::AccountId, Vec<u8>, u64),
         BurnTransactionProposed(u64, Vec<u8>, u64),
         BurnTransactionSignatureAdded(u64, StellarSignature),
         BurnTransactionReady(u64),
@@ -490,8 +490,8 @@ impl<T: Config> Pallet<T> {
 
         let burn_amount_as_u64 = amount.saturated_into::<u64>() - withdraw_fee;
         Self::deposit_event(Event::BurnTransactionCreated(
-            source,
             burn_id,
+            source,
             target_stellar_address.clone(),
             burn_amount_as_u64,
         ));

--- a/pallet-tft-bridge/src/lib.rs
+++ b/pallet-tft-bridge/src/lib.rs
@@ -169,7 +169,7 @@ pub mod pallet {
         MintCompleted(MintTransaction<T::AccountId, T::BlockNumber>),
         MintTransactionExpired(Vec<u8>, u64, T::AccountId),
         // Burn events
-        BurnTransactionCreated(u64, Vec<u8>, u64),
+        BurnTransactionCreated(T::AccountId, u64, Vec<u8>, u64),
         BurnTransactionProposed(u64, Vec<u8>, u64),
         BurnTransactionSignatureAdded(u64, StellarSignature),
         BurnTransactionReady(u64),
@@ -208,40 +208,40 @@ pub mod pallet {
     }
 
     #[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
-		pub validator_accounts: Option<Vec<T::AccountId>>,
+    pub struct GenesisConfig<T: Config> {
+        pub validator_accounts: Option<Vec<T::AccountId>>,
         pub fee_account: Option<T::AccountId>,
         pub withdraw_fee: u64,
         pub deposit_fee: u64,
-	}
+    }
 
     // The default value for the genesis config type.
-	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			Self { 
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self {
                 validator_accounts: None,
                 fee_account: None,
                 withdraw_fee: Default::default(),
                 deposit_fee: Default::default(),
             }
-		}
-	}
+        }
+    }
 
-	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-		fn build(&self) {
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
             if let Some(validator_accounts) = &self.validator_accounts {
                 Validators::<T>::put(validator_accounts);
             }
 
             if let Some(ref fee_account) = self.fee_account {
-				FeeAccount::<T>::put(fee_account);
-			}
+                FeeAccount::<T>::put(fee_account);
+            }
             WithdrawFee::<T>::put(self.withdraw_fee);
             DepositFee::<T>::put(self.deposit_fee)
-		}
-	}
+        }
+    }
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -490,6 +490,7 @@ impl<T: Config> Pallet<T> {
 
         let burn_amount_as_u64 = amount.saturated_into::<u64>() - withdraw_fee;
         Self::deposit_event(Event::BurnTransactionCreated(
+            source,
             burn_id,
             target_stellar_address.clone(),
             burn_amount_as_u64,
@@ -583,18 +584,22 @@ impl<T: Config> Pallet<T> {
             block: now,
             votes: 0,
         };
-        MintTransactions::<T>::insert(tx_id.clone(), &tx);
+        MintTransactions::<T>::insert(&tx_id, &tx);
+
+        Self::deposit_event(Event::MintTransactionProposed(
+            tx_id.clone(),
+            target,
+            amount,
+        ));
 
         // Vote already
-        Self::vote_stellar_mint_transaction(tx_id.clone())?;
-
-        Self::deposit_event(Event::MintTransactionProposed(tx_id, target, amount));
+        Self::vote_stellar_mint_transaction(tx_id)?;
 
         Ok(().into())
     }
 
     pub fn vote_stellar_mint_transaction(tx_id: Vec<u8>) -> DispatchResultWithPostInfo {
-        let mint_transaction = MintTransactions::<T>::get(tx_id.clone());
+        let mint_transaction = MintTransactions::<T>::get(&tx_id);
         match mint_transaction {
             Some(mut tx) => {
                 // increment amount of votes

--- a/tfchain_bridge/go.mod
+++ b/tfchain_bridge/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/vedhavyas/go-subkey v1.0.3
 )
 
-require github.com/threefoldtech/substrate-client v0.0.0-20220907144740-7801e4e9d0a4
+require github.com/threefoldtech/substrate-client v0.0.0-20220909131311-aac132e3f2f6
 
 require (
 	github.com/ChainSafe/go-schnorrkel v1.0.0 // indirect

--- a/tfchain_bridge/go.sum
+++ b/tfchain_bridge/go.sum
@@ -510,6 +510,8 @@ github.com/threefoldtech/substrate-client v0.0.0-20220822132933-d0d75781793c h1:
 github.com/threefoldtech/substrate-client v0.0.0-20220822132933-d0d75781793c/go.mod h1:XGsrSO/mdaDkP1ERv4+ccaNDsbU97u27f7p/iQpKrTA=
 github.com/threefoldtech/substrate-client v0.0.0-20220907144740-7801e4e9d0a4 h1:mZc0EgtnFBJxTmLxOm8aFLNoGzqYu0ahkUGui2c5fXs=
 github.com/threefoldtech/substrate-client v0.0.0-20220907144740-7801e4e9d0a4/go.mod h1:XGsrSO/mdaDkP1ERv4+ccaNDsbU97u27f7p/iQpKrTA=
+github.com/threefoldtech/substrate-client v0.0.0-20220909131311-aac132e3f2f6 h1:34n/NdDFZg8equ57unFY2MJwDtJrEPPG3T9ii2zC32E=
+github.com/threefoldtech/substrate-client v0.0.0-20220909131311-aac132e3f2f6/go.mod h1:XGsrSO/mdaDkP1ERv4+ccaNDsbU97u27f7p/iQpKrTA=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=

--- a/tfchain_bridge/pkg/bridge/bridge.go
+++ b/tfchain_bridge/pkg/bridge/bridge.go
@@ -170,7 +170,7 @@ func (bridge *Bridge) processEventRecords(events *substrate.EventRecords) error 
 
 	for _, e := range events.TFTBridgeModule_BurnTransactionCreated {
 		log.Info().Uint64("ID", uint64(e.BurnTransactionID)).Msg("found burn transaction created event")
-		call, err := bridge.proposeBurnTransaction(context.Background(), e)
+		call, err := bridge.handleBurnCreated(context.Background(), e)
 		if err != nil {
 			log.Info().Msgf("error occured: +%s", err.Error())
 			continue
@@ -198,7 +198,7 @@ func (bridge *Bridge) processEventRecords(events *substrate.EventRecords) error 
 
 	for _, e := range events.TFTBridgeModule_BurnTransactionExpired {
 		log.Info().Uint64("ID", uint64(e.BurnTransactionID)).Msg("found burn transaction expired event")
-		call, err := bridge.proposeBurnTransaction(context.Background(), e)
+		call, err := bridge.handleBurnExpired(context.Background(), e)
 		if err != nil {
 			log.Info().Msgf("error occured: +%s", err.Error())
 			continue
@@ -406,7 +406,7 @@ func (bridge *Bridge) submitRefundTransaction(ctx context.Context, refundReadyEv
 	return bridge.subClient.SetRefundTransactionExecuted(bridge.identity, refund.TxHash)
 }
 
-func (bridge *Bridge) proposeBurnTransaction(ctx context.Context, burnCreatedEvent substrate.BridgeBurnTransactionCreated) (*types.Call, error) {
+func (bridge *Bridge) handleBurnCreated(ctx context.Context, burnCreatedEvent substrate.BridgeBurnTransactionCreated) (*types.Call, error) {
 	burned, err := bridge.subClient.IsBurnedAlready(bridge.identity, burnCreatedEvent.BurnTransactionID)
 	if err != nil {
 		return nil, err
@@ -417,6 +417,18 @@ func (bridge *Bridge) proposeBurnTransaction(ctx context.Context, burnCreatedEve
 		return nil, errors.New("tx burned already")
 	}
 
+	err = bridge.wallet.CheckAccount(string(burnCreatedEvent.Target))
+	if err != nil {
+		log.Info().Msgf("tx with id: %d is an invalid burn transaction, minting on chain again...", burnCreatedEvent.BurnTransactionID)
+		mintID := fmt.Sprintf("refund-%d", burnCreatedEvent.BurnTransactionID)
+		err := bridge.handleMint(big.NewInt(int64(burnCreatedEvent.Amount)), substrate.AccountID(burnCreatedEvent.Source), mintID)
+		if err != nil {
+			return nil, err
+		}
+		log.Info().Msgf("setting invalid burn transaction (%d) as executed", burnCreatedEvent.BurnTransactionID)
+		return bridge.subClient.SetBurnTransactionExecuted(bridge.identity, uint64(burnCreatedEvent.BurnTransactionID))
+	}
+
 	amount := big.NewInt(int64(burnCreatedEvent.Amount))
 	signature, sequenceNumber, err := bridge.wallet.CreatePaymentAndReturnSignature(ctx, string(burnCreatedEvent.Target), amount.Uint64(), uint64(burnCreatedEvent.BurnTransactionID))
 	if err != nil {
@@ -425,6 +437,23 @@ func (bridge *Bridge) proposeBurnTransaction(ctx context.Context, burnCreatedEve
 	log.Info().Msgf("stellar account sequence number: %d", sequenceNumber)
 
 	return bridge.subClient.ProposeBurnTransactionOrAddSig(bridge.identity, uint64(burnCreatedEvent.BurnTransactionID), string(burnCreatedEvent.Target), amount, signature, bridge.wallet.GetKeypair().Address(), sequenceNumber)
+}
+
+func (bridge *Bridge) handleBurnExpired(ctx context.Context, burnExpiredEvent substrate.BridgeBurnTransactionExpired) (*types.Call, error) {
+	err := bridge.wallet.CheckAccount(string(burnExpiredEvent.Target))
+	if err != nil {
+		log.Info().Msgf("tx with id: %d is an invalid burn transaction, setting burn as executed since we have no way to recover...", burnExpiredEvent.BurnTransactionID)
+		return bridge.subClient.SetBurnTransactionExecuted(bridge.identity, uint64(burnExpiredEvent.BurnTransactionID))
+	}
+
+	amount := big.NewInt(int64(burnExpiredEvent.Amount))
+	signature, sequenceNumber, err := bridge.wallet.CreatePaymentAndReturnSignature(ctx, string(burnExpiredEvent.Target), amount.Uint64(), uint64(burnExpiredEvent.BurnTransactionID))
+	if err != nil {
+		return nil, err
+	}
+	log.Info().Msgf("stellar account sequence number: %d", sequenceNumber)
+
+	return bridge.subClient.ProposeBurnTransactionOrAddSig(bridge.identity, uint64(burnExpiredEvent.BurnTransactionID), string(burnExpiredEvent.Target), amount, signature, bridge.wallet.GetKeypair().Address(), sequenceNumber)
 }
 
 func (bridge *Bridge) submitBurnTransaction(ctx context.Context, burnReadyEvent substrate.BurnTransactionReady) (*types.Call, error) {
@@ -456,6 +485,31 @@ func (bridge *Bridge) submitBurnTransaction(ctx context.Context, burnReadyEvent 
 	}
 
 	return bridge.subClient.SetBurnTransactionExecuted(bridge.identity, uint64(burnReadyEvent.BurnTransactionID))
+}
+
+func (bridge *Bridge) handleMint(amount *big.Int, target substrate.AccountID, mintID string) error {
+	// TODO check if we already minted for this txid
+	minted, err := bridge.subClient.IsMintedAlready(bridge.identity, mintID)
+	if err != nil && err != substrate.ErrMintTransactionNotFound {
+		return err
+	}
+
+	if minted {
+		log.Error().Msgf("transaction with id %s is already minted", mintID)
+		return errors.New("transaction already minted")
+	}
+
+	call, err := bridge.subClient.ProposeOrVoteMintTransaction(bridge.identity, mintID, target, amount)
+	if err != nil {
+		return err
+	}
+
+	hash, err := bridge.callExtrinsic(call)
+	if err != nil {
+		return err
+	}
+	log.Info().Msgf("mint call submitted with hash: %s", hash.Hex())
+	return nil
 }
 
 func (bridge *Bridge) getSubstrateAddressFromMemo(memo string) (string, error) {

--- a/tfchain_bridge/pkg/bridge/bridge.go
+++ b/tfchain_bridge/pkg/bridge/bridge.go
@@ -417,8 +417,7 @@ func (bridge *Bridge) handleBurnCreated(ctx context.Context, burnCreatedEvent su
 		return nil, errors.New("tx burned already")
 	}
 
-	err = bridge.wallet.CheckAccount(string(burnCreatedEvent.Target))
-	if err != nil {
+	if err := bridge.wallet.CheckAccount(string(burnCreatedEvent.Target)); err != nil {
 		log.Info().Msgf("tx with id: %d is an invalid burn transaction, minting on chain again...", burnCreatedEvent.BurnTransactionID)
 		mintID := fmt.Sprintf("refund-%d", burnCreatedEvent.BurnTransactionID)
 		err := bridge.handleMint(big.NewInt(int64(burnCreatedEvent.Amount)), substrate.AccountID(burnCreatedEvent.Source), mintID)
@@ -440,8 +439,7 @@ func (bridge *Bridge) handleBurnCreated(ctx context.Context, burnCreatedEvent su
 }
 
 func (bridge *Bridge) handleBurnExpired(ctx context.Context, burnExpiredEvent substrate.BridgeBurnTransactionExpired) (*types.Call, error) {
-	err := bridge.wallet.CheckAccount(string(burnExpiredEvent.Target))
-	if err != nil {
+	if err := bridge.wallet.CheckAccount(string(burnExpiredEvent.Target)); err != nil {
 		log.Info().Msgf("tx with id: %d is an invalid burn transaction, setting burn as executed since we have no way to recover...", burnExpiredEvent.BurnTransactionID)
 		return bridge.subClient.SetBurnTransactionExecuted(bridge.identity, uint64(burnExpiredEvent.BurnTransactionID))
 	}
@@ -495,7 +493,7 @@ func (bridge *Bridge) handleMint(amount *big.Int, target substrate.AccountID, mi
 	}
 
 	if minted {
-		log.Error().Msgf("transaction with id %s is already minted", mintID)
+		log.Debug().Msgf("transaction with id %s is already minted", mintID)
 		return errors.New("transaction already minted")
 	}
 

--- a/tfchain_bridge/pkg/config.go
+++ b/tfchain_bridge/pkg/config.go
@@ -26,5 +26,5 @@ type StellarSignature struct {
 	StellarAddress []byte
 }
 
-var ErrTransactionAlreadyRefunded = errors.New("Transaction is already refunded")
+var ErrTransactionAlreadyRefunded = errors.New("transaction is already refunded")
 var ErrTransactionAlreadyMinted = errors.New("transaction is already minted")

--- a/tfchain_bridge/pkg/persistency.go
+++ b/tfchain_bridge/pkg/persistency.go
@@ -2,7 +2,6 @@ package pkg
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -43,7 +42,7 @@ func (b *ChainPersistency) SaveStellarCursor(cursor string) error {
 
 func (b *ChainPersistency) GetHeight() (*Blockheight, error) {
 	var blockheight Blockheight
-	file, err := ioutil.ReadFile(b.location)
+	file, err := os.ReadFile(b.location)
 	if os.IsNotExist(err) {
 		return &blockheight, nil
 	}
@@ -64,5 +63,5 @@ func (b *ChainPersistency) Save(blockheight *Blockheight) error {
 		return err
 	}
 
-	return ioutil.WriteFile(b.location, updatedPersistency, 0644)
+	return os.WriteFile(b.location, updatedPersistency, 0644)
 }


### PR DESCRIPTION
this PR adds two specific things:

## 1: Rework Burn transactions

In the event of a `swap_to_stellar` the source account is emitted so a "refund" can be created in case the user withdraws to a non-existing / faulty stellar account. This refund, re-mints the tokens back on the user's account. The only thing the user loses here is the withdraw fee.

## 2: Rework expired Burn transaction

Expired burn transactions are a retry of a withdraw in case the bridge missed this event. If an expired burn transaction is made to a non-existing / faulty stellar account, the transaction will be marked as done. The user that initiated the transaction will essentially lose his tokens. There is no way with the current codebase to track from what account the user created the burn from. This could be added in a later iteration.  